### PR TITLE
Fixed special character in markdown cell in notebook.

### DIFF
--- a/notebooks/income_4_random_forest.ipynb
+++ b/notebooks/income_4_random_forest.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Income Prediction: Random Forest model\n",
     "\n",
-    "Build, train, and test a Random Forest model to predict whether a person's income is greater than or equal to $50k or less than $50k based on a few features collected from United States Census data. This is a binary classifier."
+    "Build, train, and test a Random Forest model to predict whether a person's income is greater than or equal to \\$50k or less than \\$50k based on a few features collected from United States Census data. This is a binary classifier."
    ]
   },
   {

--- a/notebooks/income_4_random_forest.ipynb
+++ b/notebooks/income_4_random_forest.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Income Prediction: Random Forest model\n",
     "\n",
-    "Build, train, and test a Random Forest model to predict whether a person's income is greater than or equal to \\$50k or less than \\$50k based on a few features collected from United States Census data. This is a binary classifier."
+    "Build, train, and test a Random Forest model to predict whether a person's income is greater than or equal to 50k or less than 50k based on a few features collected from United States Census data. This is a binary classifier."
    ]
   },
   {


### PR DESCRIPTION
Problem: A pair of dollar signs cause the text between those symbols to appear in italics when viewing the notebook as a web page in this GitHub project.

I was not able to reproduce this problem in other environments, such as a gist or in VS Code or in this comment.

Attempted Fix: I tried to escape the dollar sign, e.g. "\$", but that had no effect.

Fix: I removed the dollar signs. It does not change the readability of the documentation and the text displays as expected.